### PR TITLE
Add additional FormAccessible tests

### DIFF
--- a/tests/FormAccessibleAdditionalTest.php
+++ b/tests/FormAccessibleAdditionalTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use LaravelLux\Html\Eloquent\FormAccessible;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+#[\AllowDynamicProperties]
+class FormAccessibleAdditionalTest extends PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        Capsule::table('models')->truncate();
+        Model::unguard();
+    }
+
+    public function testGetAllDateCastableAttributes()
+    {
+        $model = new ModelWithDateCasts();
+
+        $expected = ['foo_at', 'bar_at', 'created_at', 'updated_at'];
+        $this->assertEqualsCanonicalizing(
+            $expected,
+            $model->getAllDateCastableAttributes()
+        );
+    }
+
+    public function testIsNestedModelDetectsLoadedRelation()
+    {
+        $model = new ModelWithDateCasts();
+
+        $this->assertFalse($model->isNestedModel('child'));
+
+        $model->setRelation('child', new ModelWithDateCasts());
+        $this->assertTrue($model->isNestedModel('child'));
+    }
+
+    public function testGetFormValueReturnsNullForMissingRelation()
+    {
+        $model = new ModelWithDateCasts();
+
+        $this->assertNull($model->getFormValue('child.name'));
+
+        $model->setRelation('child', null);
+        $this->assertNull($model->getFormValue('child.name'));
+    }
+}
+
+class ModelWithDateCasts extends Model
+{
+    use FormAccessible;
+
+    protected $table = 'models';
+
+    protected $casts = [
+        'foo_at' => 'datetime',
+        'bar_at' => 'date',
+    ];
+}


### PR DESCRIPTION
## Summary
- add FormAccessibleAdditionalTest to cover extra functionality

## Testing
- `vendor/bin/phpunit tests/FormAccessibleAdditionalTest.php`
- `vendor/bin/phpunit` *(fails: FormBuilderTest::testPasswordsNotFilled, FormBuilderTest::testFormPassword, FormBuilderTest::testSelect, FormBuilderTest::testFormWithOptionalPlaceholder, FormBuilderTest::testFormRadioWithAttributeCastToBoolean)*

------
https://chatgpt.com/codex/tasks/task_e_687d02062478832eaa9877cc8607408d