### PR TITLE
Add Componentable unit tests

### DIFF
--- a/tests/ComponentableTest.php
+++ b/tests/ComponentableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use LaravelLux\Html\Componentable;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Mockery as m;
+
+#[\AllowDynamicProperties]
+class DummyComponentable
+{
+    use Componentable;
+
+    public function __construct(Factory $view)
+    {
+        $this->view = $view;
+    }
+}
+
+#[\AllowDynamicProperties]
+class ComponentableTest extends PHPUnit\Framework\TestCase
+{
+    protected DummyComponentable $component;
+    protected $viewFactory;
+
+    protected function setUp(): void
+    {
+        $this->viewFactory = m::mock(Factory::class);
+        $this->component = new DummyComponentable($this->viewFactory);
+
+        $ref = new ReflectionProperty(DummyComponentable::class, 'components');
+        $ref->setAccessible(true);
+        $ref->setValue([]);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testComponentRegistrationAndHasComponent()
+    {
+        DummyComponentable::component('foo', 'components.foo', []);
+
+        $this->assertTrue(DummyComponentable::hasComponent('foo'));
+        $this->assertFalse(DummyComponentable::hasComponent('bar'));
+    }
+
+    public function testDynamicComponentCallMapsArguments()
+    {
+        DummyComponentable::component('alert', 'components.alert', ['type' => 'info', 'message']);
+
+        $view = m::mock(View::class);
+        $this->viewFactory->shouldReceive('make')
+            ->once()
+            ->with('components.alert', ['type' => 'error', 'message' => 'Disk full'])
+            ->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn('rendered');
+
+        $result = $this->component->alert('error', 'Disk full');
+
+        $this->assertEquals('rendered', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add Componentable unit tests

## Testing
- `vendor/bin/phpunit --filter ComponentableTest -c phpunit.xml --testdox`


------
https://chatgpt.com/codex/tasks/task_e_687d0205b21c832e98f15848918eb4e9