### PR TITLE
Add service provider tests

### DIFF
--- a/tests/HtmlServiceProviderTest.php
+++ b/tests/HtmlServiceProviderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Http\Request;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\Contracts\Session\Session;
+use LaravelLux\Html\FormBuilder;
+use LaravelLux\Html\HtmlBuilder;
+use LaravelLux\Html\HtmlServiceProvider;
+use Mockery as m;
+
+class SimpleConfig
+{
+    protected array $items = [];
+
+    public function get($key, $default = null)
+    {
+        return $this->items[$key] ?? $default;
+    }
+
+    public function set($key, $value)
+    {
+        $this->items[$key] = $value;
+    }
+}
+
+
+class HtmlServiceProviderStub extends HtmlServiceProvider
+{
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+}
+
+#[\AllowDynamicProperties]
+class HtmlServiceProviderTest extends PHPUnit\Framework\TestCase
+{
+    protected Container $app;
+    protected $blade;
+
+    protected function setUp(): void
+    {
+        $this->app = new Container();
+        $this->app->instance('config', new SimpleConfig());
+        $this->app->instance('view', m::mock(Factory::class));
+
+        $url = new UrlGenerator(new RouteCollection(), Request::create('/', 'GET'));
+        $this->app->instance('url', $url);
+        $this->app->instance('request', Request::create('/', 'GET'));
+        $session = m::mock(\Illuminate\Contracts\Session\Session::class);
+        $session->shouldReceive('token')->andReturn('token');
+        $this->app->instance('session.store', $session);
+
+        $this->blade = m::mock(BladeCompiler::class);
+        $bladeMock = $this->blade;
+        $this->app->singleton('blade.compiler', function () use ($bladeMock) {
+            return $bladeMock;
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    protected function getProvider(): HtmlServiceProvider
+    {
+        return new HtmlServiceProviderStub($this->app);
+    }
+
+    public function testRegisterBindsHtmlAndForm()
+    {
+        $provider = $this->getProvider();
+        $provider->register();
+
+        $html = $this->app->make('html');
+        $form = $this->app->make('form');
+
+        $this->assertInstanceOf(HtmlBuilder::class, $html);
+        $this->assertSame($html, $this->app->make(HtmlBuilder::class));
+        $this->assertInstanceOf(FormBuilder::class, $form);
+        $this->assertSame($form, $this->app->make(FormBuilder::class));
+    }
+
+    public function testRegisterBladeDirectives()
+    {
+        $directives = [];
+        $this->blade->shouldReceive('directive')->andReturnUsing(function ($name, $handler) use (&$directives) {
+            $directives[$name] = $handler;
+        });
+
+        $provider = $this->getProvider();
+        $provider->register();
+
+        // Resolving the blade compiler triggers the afterResolving callbacks
+        $this->app->make('blade.compiler');
+
+        $this->assertArrayHasKey('html_entities', $directives);
+        $this->assertIsCallable($directives['html_entities']);
+        $this->assertEquals('<?php echo Html::entities(\'bar\'); ?>', $directives['html_entities']("'bar'"));
+
+        $this->assertArrayHasKey('form_open', $directives);
+        $this->assertIsCallable($directives['form_open']);
+        $this->assertEquals('<?php echo Form::open(); ?>', $directives['form_open'](''));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HtmlServiceProviderTest verifying bindings and directives

## Testing
- `vendor/bin/phpunit --stop-on-failure --filter HtmlServiceProviderTest`
- `vendor/bin/phpunit` *(fails: FormBuilderTest::testPasswordsNotFilled, FormBuilderTest::testFormPassword, FormBuilderTest::testSelect, FormBuilderTest::testFormWithOptionalPlaceholder, FormBuilderTest::testFormRadioWithAttributeCastToBoolean)*

------
https://chatgpt.com/codex/tasks/task_e_687d02046764832eaef8ca844a2ab100