### PR TITLE
Add docs for html-forms configuration

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,7 @@
                 <nav class="flex flex-col justify-start py-4 px-6 md:sticky md:top-0 static">
                     <ul class="space-y-2 text-gray-700 text-md font-medium">
                         <li class="hover:bg-gray-300"><a href="#installation" class="block py-1 px-2 text-gray-900">Installation</a></li>
+                        <li class="hover:bg-gray-300"><a href="#configuration" class="block py-1 px-2 text-gray-900">Configuration</a></li>
                         <li class="hover:bg-gray-300"><a href="#important" class="block py-1 px-2 text-gray-900">Important</a></li>
                         <li class="hover:bg-gray-300"><a href="#opening-a-form" class="block py-1 px-2 text-gray-900">Opening A Form</a></li>
                         <li class="hover:bg-gray-300"><a href="#csrf-protection" class="block py-1 px-2 text-gray-900">CSRF Protection</a></li>
@@ -74,6 +75,45 @@
                 <blockquote class="mt-2 px-4 py-2 border-l-4 border-blue-500 text-blue-600 bg-blue-100 rounded-md">
                     <p>Looking to install this package in <a href="http://lumen.laravel.com" target="\_blank" class="text-blue-700 underline">Lumen</a>? First of all, making this package compatible with Lumen will require some core changes to Lumen, which we believe would dampen the effectiveness of having Lumen in the first place. Secondly, it is our belief that if you need this package in your application, then you should be using Laravel anyway.</p>
                 </blockquote>
+
+                <a id="configuration"></a>
+                <div class="font-bold text-2xl mt-10">Configuration</div>
+                <p class="my-2">Publish the configuration file to customize how form elements are generated:</p>
+                <div class="relative my-2 bg-gray-800 text-white rounded-md pr-10">
+                    <pre class="p-2 overflow-x-auto">$ <code id="code48">php artisan vendor:publish --provider=&quot;LaravelLux\\Html\\HtmlServiceProvider&quot; --tag=config</code></pre>
+                    <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#code48">
+                    </button>
+                </div>
+                <p class="my-2">The file <code>config/html-forms.php</code> contains several options:</p>
+                <ul class="list-disc ml-8">
+                    <li><code>ignore_empty_attributes</code> &ndash; attributes allowed to be empty.</li>
+                    <li><code>ignore_all_empty_attributes</code> &ndash; disable stripping of all empty attributes.</li>
+                    <li><code>allowed_boolean_values</code> &ndash; element types that may contain boolean values.</li>
+                    <li><code>default_attributes</code> &ndash; default attributes applied per element type.</li>
+                </ul>
+                <div class="font-bold text-xl mt-2">Overriding Defaults</div>
+                <p class="my-2">Edit the published config to modify these settings. For example, to apply a Bootstrap class to every element:</p>
+                <div class="relative my-2 bg-gray-800 text-white rounded-md pr-10">
+<pre class="p-2 overflow-x-auto"><code id="code49">return [
+    'default_attributes' => [
+        'all' => [
+            'class' => [
+                'form-control' => false,
+            ],
+        ],
+    ],
+];</code></pre>
+                    <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#code49">
+                    </button>
+                </div>
+                <p class="my-2">You can also extend <code>ignore_empty_attributes</code>:</p>
+                <div class="relative my-2 bg-gray-800 text-white rounded-md pr-10">
+<pre class="p-2 overflow-x-auto"><code id="code50">'ignore_empty_attributes' => [
+    'all' => ['disabled', 'checked', 'data-foo'],
+],</code></pre>
+                    <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#code50">
+                    </button>
+                </div>
 
                 <blockquote class="mt-5 px-4 py-2 border-l-4 border-yellow-500 text-yellow-600 bg-yellow-100 rounded-m">
                     <a id="important"></a>

--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,4 @@
 > :warning: **Important Update**: The `laravellux/html` package has replaced the `laravelcollective/html` package. Please replace all references of `Collective\Html` in your project with `LaravelLux\Html`. For the majority of applications, no other changes should be necessary, and your project should continue to work as expected. However, always ensure to thoroughly test your project after this update to avoid unexpected issues. Thank you for your understanding.
 
 Official documentation for Forms & Html for The Laravel Framework can be found at the [Laravel Lux by WebSE](https://website.com.se/) website.
+See the [configuration section](docs/index.html#configuration) for details on available options.


### PR DESCRIPTION
## Summary
- document configuration options in `docs/index.html`
- link new section from README

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_687e419fb0ac832e947b445232e905df