### PR TITLE
Add CSS preset feature for FormBuilder

### DIFF
--- a/config/html-forms.php
+++ b/config/html-forms.php
@@ -91,5 +91,38 @@ return [
         'color' => [],
         'submit' => [],
         'button' => []
-    ]
+    ],
+
+    /*
+     * Named presets for common CSS frameworks. These presets define
+     * default classes that will be merged into generated elements when
+     * applied via FormBuilder::setPreset().
+     */
+    'presets' => [
+        'bootstrap' => [
+            'all' => [
+                'class' => ['form-control'],
+            ],
+            'submit' => [
+                'class' => ['btn', 'btn-primary'],
+            ],
+            'button' => [
+                'class' => ['btn', 'btn-secondary'],
+            ],
+        ],
+        'tailwind' => [
+            'all' => [
+                'class' => ['border', 'p-2', 'rounded'],
+            ],
+            'submit' => [
+                'class' => ['bg-blue-500', 'text-white', 'p-2', 'rounded'],
+            ],
+            'button' => [
+                'class' => ['bg-gray-500', 'text-white', 'p-2', 'rounded'],
+            ],
+        ],
+    ],
+
+    // Preset that should be applied by default. Set to null for none.
+    'default_preset' => null,
 ];

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,7 @@
                         <li class="hover:bg-gray-300"><a href="#buttons" class="block py-1 px-2 text-gray-900">Buttons</a></li>
                         <li class="hover:bg-gray-300"><a href="#custom-macros" class="block py-1 px-2 text-gray-900">Custom Macros</a></li>
                         <li class="hover:bg-gray-300"><a href="#custom-components" class="block py-1 px-2 text-gray-900">Custom Components</a></li>
+                        <li class="hover:bg-gray-300"><a href="#css-presets" class="block py-1 px-2 text-gray-900">CSS Presets</a></li>
                         <li class="hover:bg-gray-300"><a href="#generating-urls" class="block py-1 px-2 text-gray-900">Generating URLs</a></li>
                     </ul>
                 </nav>
@@ -508,6 +509,33 @@ class User extends Model
 &lt;input type="text" name="first_name" value="" class="form-control"&gt;
 &lt;/div&gt;</code></pre>
                     <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#code43">
+                    </button>
+                </div>
+
+                <a id="css-presets"></a>
+                <div class="font-bold text-2xl mt-10">CSS Presets</div>
+                <p class="my-2">
+                    Presets allow you to automatically apply CSS classes to every generated input.
+                    Define them in <code>config/html-forms.php</code> and enable one at runtime.
+                </p>
+                <div class="relative my-2 bg-gray-800 text-white rounded-md pr-10">
+                    <pre class="p-2 overflow-x-auto"><code id="codePreset1">'presets' =&gt; [
+    'bootstrap' =&gt; [
+        'all' =&gt; ['class' =&gt; ['form-control']],
+        'submit' =&gt; ['class' =&gt; ['btn', 'btn-primary']],
+    ],
+]</code></pre>
+                    <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#codePreset1">
+                    </button>
+                </div>
+                <div class="relative my-2 bg-gray-800 text-white rounded-md pr-10">
+                    <pre class="p-2 overflow-x-auto"><code id="codePreset2">Form::setPreset('bootstrap');</code></pre>
+                    <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#codePreset2">
+                    </button>
+                </div>
+                <div class="relative my-2 bg-gray-800 text-white rounded-md pr-10">
+                    <pre class="p-2 overflow-x-auto"><code id="codePreset3">Form::addPreset('custom', ['all' =&gt; ['class' =&gt; ['my-class']]]);</code></pre>
+                    <button class="md:inline hidden copyBtn absolute right-2 top-2" aria-label="Copy to Clipboard" title="Copy to Clipboard" data-clipboard-target="#codePreset3">
                     </button>
                 </div>
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -107,6 +107,20 @@ class FormBuilder
      */
     protected array $skipValueTypes = ['file', 'password', 'checkbox', 'radio'];
 
+    /**
+     * Available CSS presets loaded from configuration.
+     *
+     * @var array
+     */
+    protected array $presets = [];
+
+    /**
+     * Currently active preset name.
+     *
+     * @var string|null
+     */
+    protected ?string $currentPreset = null;
+
 
     /**
      * Input Type.
@@ -137,6 +151,8 @@ class FormBuilder
         $this->view = $view;
         $this->csrfToken = $csrfToken;
         $this->request = $request;
+        $this->presets = config('html-forms.presets', []);
+        $this->currentPreset = config('html-forms.default_preset');
     }
 
     /**
@@ -183,6 +199,9 @@ class FormBuilder
           $attributes, Arr::except($options, $this->reserved)
 
         );
+
+        // Apply preset defaults before rendering.
+        $attributes = $this->applyPreset('form', $attributes);
 
         /**
         ** Finally, we will concatenate all the attributes into a single string so
@@ -284,6 +303,7 @@ class FormBuilder
     {
         $this->labels[] = $name;
 
+        $options = $this->applyPreset('label', $options);
         $options = $this->html->attributes($options, 'label');
 
         $value = $this->formatLabel($name, $value);
@@ -341,6 +361,8 @@ class FormBuilder
         $merge = compact('type', 'value', 'id');
 
         $options = array_merge($options, $merge);
+
+        $options = $this->applyPreset($type, $options);
 
         return $this->toHtmlString('<input' . $this->html->attributes($options, $type) . '>');
     }
@@ -609,6 +631,7 @@ class FormBuilder
          * the size attribute, as it was merely a short-cut for the rows and cols on
          * the element. Then we'll create the final textarea elements HTML for us.
          **/
+        $options = $this->applyPreset('textarea', $options);
         $options = $this->html->attributes($options, 'textarea');
 
         return $this->toHtmlString('<textarea' . $options . '>' . e($value, false). '</textarea>');
@@ -706,6 +729,7 @@ class FormBuilder
         // Once we have all of this HTML, we can join this into a single element after
         // formatting the attributes into an HTML "attributes" string, then we will
         // build out a final select statement, which will contain all the values.
+        $selectAttributes = $this->applyPreset('select', $selectAttributes);
         $selectAttributes = $this->html->attributes($selectAttributes, 'select');
 
         $list = implode('', $html);
@@ -1123,6 +1147,8 @@ class FormBuilder
             $options['type'] = 'button';
         }
 
+        $options = $this->applyPreset('button', $options);
+
         return $this->toHtmlString('<button' . $this->html->attributes($options, 'button') . '>' . $value . '</button>');
     }
 
@@ -1152,6 +1178,7 @@ class FormBuilder
             }
         }
 
+        $attributes = $this->applyPreset('datalist', $attributes);
         $attributes = $this->html->attributes($attributes, 'datalist');
 
         $list = implode('', $html);
@@ -1481,6 +1508,58 @@ class FormBuilder
     protected function toHtmlString($html): HtmlString
     {
         return new HtmlString($html);
+    }
+
+    /**
+     * Register a new CSS preset.
+     */
+    public function addPreset(string $name, array $preset): static
+    {
+        $this->presets[$name] = $preset;
+
+        return $this;
+    }
+
+    /**
+     * Activate a preset by name. Use null to disable presets.
+     */
+    public function setPreset(?string $name): static
+    {
+        $this->currentPreset = $name;
+
+        return $this;
+    }
+
+    /**
+     * Apply the currently selected preset to the element attributes.
+     */
+    protected function applyPreset(string $type, array $attributes = null): array
+    {
+        $attributes = $attributes ?? [];
+
+        if ($this->currentPreset && isset($this->presets[$this->currentPreset])) {
+            $preset = $this->presets[$this->currentPreset];
+
+            foreach (['all', $type] as $section) {
+                if (!isset($preset[$section])) {
+                    continue;
+                }
+                foreach ($preset[$section] as $key => $value) {
+                    if ($key === 'class') {
+                        $current = $attributes['class'] ?? [];
+                        if (!is_array($current)) {
+                            $current = array_filter(explode(' ', (string) $current));
+                        }
+                        $vals = is_array($value) ? $value : array_filter(explode(' ', (string) $value));
+                        $attributes['class'] = array_values(array_unique(array_merge($vals, $current)));
+                    } else {
+                        $attributes[$key] = $attributes[$key] ?? $value;
+                    }
+                }
+            }
+        }
+
+        return $attributes;
     }
 
     /**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -998,6 +998,22 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
         $this->formBuilder->thisMethodDoesNotExist();
     }
 
+    public function testPresetClassesAreApplied()
+    {
+        $this->formBuilder->addPreset('test', [
+            'all' => ['class' => ['preset']],
+            'submit' => ['class' => ['btn']],
+        ]);
+
+        $this->formBuilder->setPreset('test');
+
+        $text = $this->formBuilder->text('foo');
+        $submit = $this->formBuilder->submit('Save');
+
+        $this->assertEquals('<input name="foo" type="text" class="preset">', $text);
+        $this->assertEquals('<input type="submit" value="Save" class="btn preset">', $submit);
+    }
+
     protected function setModel(array $data, $object = true)
     {
         if ($object) {


### PR DESCRIPTION
## Summary
- define preset config for Bootstrap and Tailwind
- add preset management to `FormBuilder`
- apply presets to generated form elements
- document presets in docs
- test preset behaviour

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687e41ee58ac832e829b8657f6cfa823