### PR TITLE
Add transformKey and session store tests

### DIFF
--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -998,6 +998,24 @@ class FormBuilderTest extends PHPUnit\Framework\TestCase
         $this->formBuilder->thisMethodDoesNotExist();
     }
 
+    public function testTransformKeyWithNestedArrayKeys()
+    {
+        $ref = new ReflectionMethod(FormBuilder::class, 'transformKey');
+        $ref->setAccessible(true);
+
+        $result = $ref->invoke($this->formBuilder, 'foo[bar][baz]');
+
+        $this->assertEquals('foo.bar.baz', $result);
+    }
+
+    public function testSetAndGetSessionStore()
+    {
+        $store = new Store('test', new SessionHandler());
+        $this->formBuilder->setSessionStore($store);
+
+        $this->assertSame($store, $this->formBuilder->getSessionStore());
+    }
+
     public function testPresetClassesAreApplied()
     {
         $this->formBuilder->addPreset('test', [


### PR DESCRIPTION
## Summary
- test FormBuilder::transformKey via reflection on nested array keys
- check setSessionStore returns same instance via getSessionStore

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6881ece4cb14832e8862b15173d3b604