### PR TITLE
Add test for FormAccessible reflection cache

### DIFF
--- a/tests/FormAccessibleReflectionTest.php
+++ b/tests/FormAccessibleReflectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use LaravelLux\Html\Eloquent\FormAccessible;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+#[\AllowDynamicProperties]
+class FormAccessibleReflectionTest extends PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        Capsule::table('models')->truncate();
+        Model::unguard();
+    }
+
+    public function testReflectionIsCachedForMutators()
+    {
+        $model = new DummyReflectionModel(['string' => 'foo']);
+
+        $model->getFormValue('string');
+        $firstReflection = $model->getReflectionInstance();
+        $this->assertSame(1, $model->getReflectionCount());
+
+        $model->getFormValue('string');
+        $secondReflection = $model->getReflectionInstance();
+
+        $this->assertSame(1, $model->getReflectionCount());
+        $this->assertSame($firstReflection, $secondReflection);
+    }
+}
+
+class DummyReflectionModel extends Model
+{
+    use FormAccessible { getReflection as protected baseGetReflection; }
+
+    protected $table = 'models';
+
+    public int $reflectionCount = 0;
+
+    protected function getReflection()
+    {
+        if (! $this->reflection) {
+            $this->reflectionCount++;
+        }
+
+        return $this->baseGetReflection();
+    }
+
+    public function getReflectionCount(): int
+    {
+        return $this->reflectionCount;
+    }
+
+    public function getReflectionInstance(): ?\ReflectionClass
+    {
+        return $this->reflection;
+    }
+
+    public function formStringAttribute($value)
+    {
+        return strtoupper($value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a test verifying that FormAccessible caches ReflectionClass

## Testing
- `vendor/bin/phpunit -c phpunit.xml --filter FormAccessibleReflectionTest`
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6881ece42858832e88b6cb9729b5b1ff