### PR TITLE
Add HtmlBuilder undefined method test

### DIFF
--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -228,4 +228,10 @@ class HtmlBuilderTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('person&#64;example.com', $builder->email('person@example.com'));
         $this->assertEquals('&nbsp;&nbsp;&nbsp;', $this->htmlBuilder->nbsp(3));
     }
+
+    public function testCallUndefinedMethodThrowsException()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->htmlBuilder->nonExisting();
+    }
 }


### PR DESCRIPTION
## Summary
- add test verifying HtmlBuilder throws BadMethodCallException when calling an undefined method

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6881ece37f6c832e9d4cbbe03e6b157f