### PR TITLE
Add return types to reflection helpers

### DIFF
--- a/src/Eloquent/FormAccessible.php
+++ b/src/Eloquent/FormAccessible.php
@@ -114,7 +114,7 @@ trait FormAccessible
      *
      * @return mixed
      */
-    private function mutateFormAttribute($key, $value)
+    private function mutateFormAttribute($key, $value): mixed
     {
         return $this->{'form' . Str::studly($key) . 'Attribute'}($value);
     }
@@ -123,7 +123,7 @@ trait FormAccessible
      * Get a ReflectionClass Instance
      * @return ReflectionClass
      */
-    protected function getReflection()
+    protected function getReflection(): ReflectionClass
     {
         if (! $this->reflection) {
             $this->reflection = new ReflectionClass($this);

--- a/tests/FormAccessibleReflectionTest.php
+++ b/tests/FormAccessibleReflectionTest.php
@@ -37,7 +37,7 @@ class DummyReflectionModel extends Model
 
     public int $reflectionCount = 0;
 
-    protected function getReflection()
+    protected function getReflection(): \ReflectionClass
     {
         if (! $this->reflection) {
             $this->reflectionCount++;


### PR DESCRIPTION
## Summary
- add explicit return types for FormAccessible helpers
- adjust reflection test to match new signature

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6884f355d500832eb8b825b75877e36c